### PR TITLE
Sort bgi entries by chromosome

### DIFF
--- a/scripts/utils.R
+++ b/scripts/utils.R
@@ -225,6 +225,8 @@ load_bgen<-function(x,threads,subset_subIDs=NULL) {
     if (!file.exists(subset_bk_file)) { 
         
       bgi<-snp_readBGI(bgi_file,snp_id=NULL)
+      sorted_idx <- order(as.integer(bgi$chromosome))
+      bgi <- bgi[sorted_idx, ] # Sort bgi dataframe based on the 'chromosome' column
       snps_ids<-list(paste(bgi$chromosome, bgi$position, bgi$allele1, bgi$allele2, sep="_")) #do we want this or an external table?
       sampleIDs<-fread2(sample_file)[-1, ]$ID_2
       ind_row<-sort(match(subset_subIDs, sampleIDs))
@@ -244,6 +246,8 @@ load_bgen<-function(x,threads,subset_subIDs=NULL) {
     if (!file.exists(bk_file)) {
 
       bgi<-snp_readBGI(bgi_file,snp_id=NULL)
+      sorted_idx <- order(as.integer(bgi$chromosome))
+      bgi <- bgi[sorted_idx, ] # Sort bgi dataframe based on the 'chromosome' column
       snps_ids<-list(paste(bgi$chromosome, bgi$position, bgi$allele1, bgi$allele2, sep="_")) #do we want this or an external table?
       snp_readBGEN(bgen_file, backingfile=backing_file, list_snp_id=snps_ids, ncores=threads, read_as ="dosage")
 


### PR DESCRIPTION
If the `chromsome` column of the .bgi file (i.e. SQL database) is a string, `snp_readBGI` will load the variants in alphabetical order w.r.t. `chromsome`. So, variants will be in this order: `1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 21, 22, 3, 4, 5, 6, 7, 8, 9` and `POS2` computed by `snp_asGeneticPos` will be wrong, resulting in an error during `snp_cor`.

The proposed PR orders the dataframe returned by `snp_readBGI` by treating `chromsome` as an integer, resulting in the natural ordering `1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22`.